### PR TITLE
Integration of Python Extensions for Development Environment

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,11 +9,16 @@
   "customizations": {
     "vscode": {
       "extensions": [
-        "ms-iot.vscode-ros",
-        "GitHub.copilot",
         "GitHub.copilot-chat",
+        "GitHub.copilot",
+        "medo64.render-crlf",
+        "mhutchie.git-graph",
+        "ms-iot.vscode-ros",
+        "ms-python.autopep8",
+        "ms-python.flake8",
+        "ms-python.isort",
         "ms-python.vscode-pylance",
-        "mhutchie.git-graph"
+        "njpwerner.autodocstring"
       ]
     }
   }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,7 +12,7 @@
         "ms-iot.vscode-ros",
         "GitHub.copilot",
         "GitHub.copilot-chat",
-        "ms-python.python",
+        "ms-python.vscode-pylance",
         "mhutchie.git-graph"
       ]
     }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,7 +18,8 @@
         "ms-python.flake8",
         "ms-python.isort",
         "ms-python.vscode-pylance",
-        "njpwerner.autodocstring"
+        "njpwerner.autodocstring",
+        "VisualStudioExptTeam.vscodeintellicode"
       ]
     }
   }


### PR DESCRIPTION
Adding extensions that I think are important for python development, as well as some general extensions that I think should always be included.

For python:
- `ms-python.autopep8`: Formatting support for Python files using the autopep8 formatter.
- `ms-python.flake8`: Linting support for Python files using Flake8.
- `ms-python.isort`: Import organization support for Python files using isort
- `njpwerner.autodocstring`: Generates python docstrings automatically
-  `ms-python.vscode-pylance` instead of `ms-python.python`: A performant, feature-rich LSP (language server) for Python.

For general purpose:
- `medo64.render-crlf`: Displays the line ending symbol and optionally extra whitespace when 'Render whitespace' is turned on. (no more extra whitespace....)
- `VisualStudioExptTeam.vscodeintellicode`: Allow for more autocompletion, even without an LSP.
