### PR TITLE
change version from fortress to harmonic

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/clubcapra/gazebo:latest
+FROM ghcr.io/clubcapra/gazebo:harmonic
 
 # Add vscode user with same UID and GID as your host system
 # (copied from https://code.visualstudio.com/remote/advancedcontainers/add-nonroot-user#_creating-a-nonroot-user)
@@ -19,7 +19,7 @@ RUN apt upgrade -y
 RUN apt install -y git
 
 # Install ROS dependencies
-RUN apt install -y ros-humble-xacro ros-humble-ros-gz-bridge ros-humble-rviz2 ros-humble-slam-toolbox ros-humble-robot-localization
+RUN apt install -y ros-humble-xacro ros-humble-rviz2 ros-humble-slam-toolbox ros-humble-robot-localization
 # apt-get -y install ros-humble-velodyne-gazebo-plugins
 # Rosdep update
 RUN rosdep update

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,7 +19,8 @@
         "ms-python.isort",
         "ms-python.vscode-pylance",
         "njpwerner.autodocstring",
-        "VisualStudioExptTeam.vscodeintellicode"
+        "VisualStudioExptTeam.vscodeintellicode",
+        "jebbs.plantuml"
       ]
     }
   }

--- a/src/rove_description/urdf/lidar.urdf.xacro
+++ b/src/rove_description/urdf/lidar.urdf.xacro
@@ -32,8 +32,8 @@
     <gazebo reference="laser_frame">
         <material>Gazebo/Black</material>
 
-        <sensor name='laser_sensor_frame' type='gpu_lidar'>"
-            <ignition_frame_id>rove/laser_frame</ignition_frame_id>
+        <sensor name='laser_sensor_frame' type='gpu_lidar'>
+            <gz_frame_id>rove/laser_frame</gz_frame_id>
             <pose> 0 0 0 0 0 0 </pose>
             <visualize>false</visualize>
             <always_on>false</always_on>

--- a/src/rove_description/worlds/base_world.world
+++ b/src/rove_description/worlds/base_world.world
@@ -21,10 +21,10 @@
             <real_time_update_rate>1000</real_time_update_rate>
         </physics>
 
-        <plugin name='ignition::gazebo::systems::Physics' filename='ignition-gazebo-physics-system'/>
-        <plugin name='ignition::gazebo::systems::UserCommands' filename='ignition-gazebo-user-commands-system'/>
-        <plugin name='ignition::gazebo::systems::SceneBroadcaster' filename='ignition-gazebo-scene-broadcaster-system'/>
-        <plugin name='ignition::gazebo::systems::Contact' filename='ignition-gazebo-contact-system'/>
+        <plugin name='gz::sim::systems::Physics' filename='gz-sim-physics-system'/>
+        <plugin name='gz::sim::systems::UserCommands' filename='gz-sim-user-commands-system'/>
+        <plugin name='gz::sim::systems::SceneBroadcaster' filename='gz-sim-scene-broadcaster-system'/>
+        <plugin name='gz::sim::systems::Contact' filename='gz-sim-contact-system'/>
 
         <light type="directional" name="sun">
           <cast_shadows>true</cast_shadows>


### PR DESCRIPTION
I added tag support to https://github.com/clubcapra/gazebo_docker and made the change to switch from Fortress to Harmonic (Gazebo [Simulator] version).

The total dev container image size have been reduce from 14.5 Gb to 5 Gb.

Note :
I wasn't able to install ros2 control without compiling. It seems that the compiled version of Fortress broke something in ros2 control and we would had to compile it manually. 