### PR TITLE
change apt to rosdep

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -36,6 +36,3 @@ RUN rosdep install --from-paths src --ignore-src --rosdistro humble -y
 # Source the ROS setup file
 RUN echo "source /opt/ros/${ROS_DISTRO}/setup.bash" >> ~/.bashrc
 RUN echo "source /gazebo/gazebo_ws/install/setup.bash" >> ~/.bashrc
-
-
-

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,10 +1,15 @@
 FROM ghcr.io/clubcapra/gazebo:harmonic
 
+
+
 # Add vscode user with same UID and GID as your host system
 # (copied from https://code.visualstudio.com/remote/advancedcontainers/add-nonroot-user#_creating-a-nonroot-user)
 ARG USERNAME=rove
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
+
+WORKDIR /workspace/$USERNAME
+
 RUN groupadd --gid $USER_GID $USERNAME \
     && useradd -s /bin/bash --uid $USER_UID --gid $USER_GID -m $USERNAME \
     && apt-get update \
@@ -13,20 +18,24 @@ RUN groupadd --gid $USER_GID $USERNAME \
     && chmod 0440 /etc/sudoers.d/$USERNAME
 
 # Update all packages
-RUN apt upgrade -y
+RUN apt update && apt upgrade -y
 
 # Install Git
 RUN apt install -y git
 
-# Install ROS dependencies
-RUN apt install -y ros-humble-xacro ros-humble-rviz2 ros-humble-slam-toolbox ros-humble-robot-localization
-# apt-get -y install ros-humble-velodyne-gazebo-plugins
-# Rosdep update
-RUN rosdep update
+# Copy to preload the ros packages
+COPY ./ /workspace/$USERNAME/
 
 # Change user
 USER $USERNAME
 
+# Rosdep update
+RUN rosdep update
+RUN rosdep install --from-paths src --ignore-src --rosdistro humble -y
+
 # Source the ROS setup file
 RUN echo "source /opt/ros/${ROS_DISTRO}/setup.bash" >> ~/.bashrc
 RUN echo "source /gazebo/gazebo_ws/install/setup.bash" >> ~/.bashrc
+
+
+

--- a/src/rove_bringup/package.xml
+++ b/src/rove_bringup/package.xml
@@ -6,8 +6,6 @@
   <description>The rove_bringup package</description>
   <maintainer email="capra@ens.etsmtl.ca">Capra</maintainer>
   <license>GPLv3</license>
-
-  <buildtool_depend>catkin</buildtool_depend>
   
   <build_depend>joy</build_depend>
   <build_depend>teleop_twist_joy</build_depend>

--- a/src/rove_description/package.xml
+++ b/src/rove_description/package.xml
@@ -7,6 +7,10 @@
   <maintainer email="capra@ens.etsmtl.ca">Capra</maintainer>
   <license>MIT</license>
 
+  <exec_depend>rviz2</exec_depend>
+  <exec_depend>xacro</exec_depend>
+  <exec_depend>ros_gz_bridge</exec_depend>
+
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <test_depend>ament_lint_auto</test_depend>

--- a/src/rove_slam/package.xml
+++ b/src/rove_slam/package.xml
@@ -3,9 +3,14 @@
 <package format="3">
   <name>rove_slam</name>
   <version>0.0.0</version>
-  <description>TODO: Package description</description>
-  <maintainer email="simonroy99@hotmail.ca">rove</maintainer>
+  <description>SLAM package for rove</description>
+  <maintainer email="capra@ens.etsmtl.ca">rove</maintainer>
   <license>TODO: License declaration</license>
+
+
+  <exec_depend>slam_toolbox</exec_depend>
+  <exec_depend>robot_localization</exec_depend>
+
 
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>


### PR DESCRIPTION
What : 
When a user is building natively (ubuntu), he can now use rosdep install and standard ros package management. This align with ROS philosophy.

Why : 
Ease the building process, and ensure that packages outside the repository are downloaded