### PR TITLE
Added capra_opi back cuz it got bumped by a pull request

### DIFF
--- a/rove.repos
+++ b/rove.repos
@@ -11,3 +11,7 @@ repositories:
     type: git
     url: https://github.com/dawonn/vectornav.git
     version: ros2
+  capra_opi:
+    type: git
+    url: https://github.com/clubcapra/capra_opi.git
+    version: master


### PR DESCRIPTION
For some reason the VCS for capra-opi got removed during a merge.
This PR is to add it back.